### PR TITLE
Fix #18: Isolate E2E tests from production database

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "husky install",
     "daemon:status": "bash scripts/daemon-status.sh",
     "daemon:restore": "bash scripts/restore-hosts.sh",
+    "db:cleanup-test-data": "bash scripts/cleanup-test-data.sh",
     "install:production": "bash scripts/install-production.sh",
     "uninstall:production": "bash scripts/uninstall-production.sh"
   },

--- a/packages/backend/src/routes/status.test.ts
+++ b/packages/backend/src/routes/status.test.ts
@@ -29,6 +29,7 @@ describe('Status API', () => {
       expect(response.body.success).toBe(true);
       expect(response.body.data.isRunning).toBe(true);
       expect(response.body.data.lastCheck).toBeDefined();
+      expect(response.body.data.environment).toBeDefined();
     });
 
     it('should return not running status when daemon is unreachable', async () => {

--- a/packages/backend/src/routes/status.ts
+++ b/packages/backend/src/routes/status.ts
@@ -14,6 +14,7 @@ router.get('/status', async (_req: Request, res: Response, next: NextFunction) =
       data: {
         isRunning,
         lastCheck: new Date().toISOString(),
+        environment: process.env.NODE_ENV || 'development',
       },
     });
   } catch (error) {

--- a/packages/e2e/global-setup.ts
+++ b/packages/e2e/global-setup.ts
@@ -1,0 +1,47 @@
+import { request } from '@playwright/test';
+
+/**
+ * Global setup that runs before all E2E tests.
+ * Ensures tests are not running against production environment.
+ */
+async function globalSetup(): Promise<void> {
+  const baseURL = process.env.BASE_URL || 'http://localhost:5174';
+
+  // Check if we're accidentally pointing at production ports
+  if (baseURL.includes(':5173') || baseURL.includes(':3000')) {
+    throw new Error(
+      `E2E tests are configured to run against production ports!\n` +
+        `Current baseURL: ${baseURL}\n` +
+        `E2E tests must run against development ports (5174/3001).\n` +
+        `Check playwright.config.ts baseURL setting.`
+    );
+  }
+
+  // Verify the backend is running in development mode
+  const context = await request.newContext({ baseURL });
+  try {
+    const response = await context.get('/api/status');
+    if (response.ok()) {
+      const data = await response.json();
+      const environment = data.data?.environment;
+
+      if (environment === 'production') {
+        throw new Error(
+          `E2E tests detected a production backend!\n` +
+            `Backend reports environment: ${environment}\n` +
+            `E2E tests must not run against production.\n` +
+            `Start the dev server with: npm run dev`
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('E2E tests')) {
+      throw error;
+    }
+    // Server not running yet is OK - webServer config will start it
+  } finally {
+    await context.dispose();
+  }
+}
+
+export default globalSetup;

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
+  globalSetup: './global-setup.ts',
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
@@ -8,7 +9,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:5174',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
@@ -29,7 +30,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev',
     cwd: '../..',
-    port: 5173,
+    port: 5174,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/scripts/cleanup-test-data.sh
+++ b/scripts/cleanup-test-data.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Cleanup script to remove test data from production database
+# Test habits have names ending with 13-digit timestamps (e.g., "Exercise 1768745721300")
+
+set -e
+
+PROD_DB="${HOME}/.habit-tracker/data/habit-tracker.db"
+
+if [ ! -f "$PROD_DB" ]; then
+  echo "Production database not found at: $PROD_DB"
+  exit 1
+fi
+
+echo "=== Habit Tracker Test Data Cleanup ==="
+echo "Database: $PROD_DB"
+echo ""
+
+# Count test habits (names ending with 13-digit timestamp)
+TEST_HABIT_COUNT=$(sqlite3 "$PROD_DB" "SELECT COUNT(*) FROM habits WHERE name GLOB '*[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]';")
+
+if [ "$TEST_HABIT_COUNT" -eq 0 ]; then
+  echo "No test habits found. Database is clean."
+  exit 0
+fi
+
+echo "Found $TEST_HABIT_COUNT test habit(s):"
+echo ""
+sqlite3 "$PROD_DB" "SELECT '  - ' || name FROM habits WHERE name GLOB '*[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]';"
+echo ""
+
+if [ "$1" != "--force" ]; then
+  read -p "Delete these habits and their logs? [y/N] " -n 1 -r
+  echo ""
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+# Get IDs of test habits
+TEST_HABIT_IDS=$(sqlite3 "$PROD_DB" "SELECT id FROM habits WHERE name GLOB '*[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]';")
+
+# Delete habit logs first (foreign key constraint)
+for id in $TEST_HABIT_IDS; do
+  sqlite3 "$PROD_DB" "DELETE FROM habit_logs WHERE habit_id = '$id';"
+done
+
+# Delete test habits
+sqlite3 "$PROD_DB" "DELETE FROM habits WHERE name GLOB '*[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]';"
+
+echo "✓ Deleted $TEST_HABIT_COUNT test habit(s) and their logs."


### PR DESCRIPTION
Closes #18

## Summary
- E2E tests now run against development ports (5174/3001) instead of production
- Added global setup that fails fast if tests accidentally target production
- Added cleanup script to remove test artifacts from production DB

## Changes
- **E2E config**: Changed baseURL to 5174, added global-setup.ts safeguard
- **Backend**: Added `environment` field to `/api/status` response
- **Scripts**: Added `cleanup-test-data.sh` and npm script `db:cleanup-test-data`

## Test plan
- [x] Backend status tests pass with new environment field
- [x] Cleanup script successfully removed 23 test habits from production DB
- [ ] Run E2E tests to verify they work against dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)