### PR TITLE
Fix #26: Allow editing data values for completed habits

### DIFF
--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -841,6 +841,15 @@
   font-weight: 600;
 }
 
+.graph-chart circle {
+  cursor: pointer;
+  transition: r 0.2s;
+}
+
+.graph-chart circle:hover {
+  r: 6;
+}
+
 /* Global Settings Page */
 .settings-page {
   max-width: 600px;

--- a/packages/frontend/src/api/client.test.ts
+++ b/packages/frontend/src/api/client.test.ts
@@ -135,6 +135,20 @@ describe('API Client', () => {
 
       expect(global.fetch).toHaveBeenCalledWith('/api/habits/1/graph', expect.any(Object));
     });
+
+    it('updateLogDataValue patches log data', async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        json: () => Promise.resolve({ success: true, data: { id: 'log-1', dataValue: 180 } }),
+      } as Response);
+
+      await habitsApi.updateLogDataValue('habit-1', '2024-01-15', 180);
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/habits/habit-1/logs/date/2024-01-15', {
+        method: 'PATCH',
+        body: JSON.stringify({ dataValue: 180 }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
   });
 
   describe('settingsApi', () => {

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -89,6 +89,13 @@ export const habitsApi = {
     const query = params.toString() ? `?${params.toString()}` : '';
     return fetchApi<{ unit?: string; points: GraphDataPoint[] }>(`/habits/${id}/graph${query}`);
   },
+
+  async updateLogDataValue(habitId: string, date: string, dataValue: number): Promise<ApiResponse<HabitLog>> {
+    return fetchApi<HabitLog>(`/habits/${habitId}/logs/date/${date}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ dataValue }),
+    });
+  },
 };
 
 export const settingsApi = {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -66,6 +66,10 @@ export interface SkipHabitRequest {
   notes?: string;
 }
 
+export interface UpdateHabitLogRequest {
+  dataValue: number;
+}
+
 export interface DaemonStatus {
   isRunning: boolean;
   lastCheck?: string; // ISO timestamp


### PR DESCRIPTION
Closes #26

## Summary
- Users can now click data points in GraphView to edit their values
- Added PATCH endpoint for updating habit log data values by date
- Graph updates immediately after successful save

## Changes
- `packages/shared/src/types.ts`: Added `UpdateHabitLogRequest` interface
- `packages/backend/src/routes/habits.ts`: Added PATCH `/api/habits/:id/logs/date/:date` endpoint
- `packages/backend/src/routes/habits.test.ts`: Added 7 test cases for the endpoint
- `packages/frontend/src/api/client.ts`: Added `updateLogDataValue` method
- `packages/frontend/src/api/client.test.ts`: Added API client test
- `packages/frontend/src/components/GraphView.tsx`: Added click handler and edit modal
- `packages/frontend/src/components/GraphView.test.tsx`: Added 6 edit interaction tests
- `packages/frontend/src/App.css`: Added hover styles for graph circles

## Testing
- All backend tests pass (85 tests)
- All frontend tests pass (31 GraphView tests, including 6 new edit tests)
- Build succeeds for all packages
- Manual testing: click data point → edit value → save → graph updates