### PR TITLE
feat(frontend): add environment-specific favicons

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-dev.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Habit Tracker</title>
   </head>

--- a/packages/frontend/public/favicon-dev.svg
+++ b/packages/frontend/public/favicon-dev.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#f97316" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="20 6 9 17 4 12"/>
+</svg>

--- a/packages/frontend/public/favicon-prod.svg
+++ b/packages/frontend/public/favicon-prod.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="20 6 9 17 4 12"/>
+</svg>

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -28,6 +28,19 @@ function versionMetaPlugin(): Plugin {
   };
 }
 
+function faviconPlugin(): Plugin {
+  const favicon = NODE_ENV === 'production' ? '/favicon-prod.svg' : '/favicon-dev.svg';
+  return {
+    name: 'favicon-env',
+    transformIndexHtml(html) {
+      return html.replace(
+        /<link rel="icon" type="image\/svg\+xml" href="[^"]*" \/>/,
+        `<link rel="icon" type="image/svg+xml" href="${favicon}" />`
+      );
+    },
+  };
+}
+
 const VITE_PORT = parseInt(process.env.VITE_PORT || '5173', 10);
 const BACKEND_PORT = process.env.PORT || '3000';
 
@@ -42,7 +55,7 @@ if (process.env.VITE_ALLOWED_HOSTS) {
 }
 
 export default defineConfig({
-  plugins: [react(), versionMetaPlugin()],
+  plugins: [react(), versionMetaPlugin(), faviconPlugin()],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- Add green checkmark favicon for production environment
- Add orange checkmark favicon for development environment
- Create faviconPlugin in vite.config.ts to swap favicons based on NODE_ENV

## Test plan
- [ ] Run `npm run dev` → verify orange favicon appears in browser tab
- [ ] Run `npm run start:prod` → verify green favicon appears in browser tab
- [ ] Run `npm run build` → verify both favicon files are copied to dist/

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)