### PR TITLE
Closes #43: Configure VitePress to aggregate package READMEs

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -32,6 +32,15 @@ export default defineConfig({
             { text: 'System Design', link: '/guide/architecture' },
           ],
         },
+        {
+          text: 'Packages',
+          items: [
+            { text: 'Shared', link: '/guide/shared' },
+            { text: 'Backend', link: '/guide/backend' },
+            { text: 'Frontend', link: '/guide/frontend' },
+            { text: 'Daemon', link: '/guide/daemon' },
+          ],
+        },
       ],
       '/api/': [
         {

--- a/packages/docs/guide/backend.md
+++ b/packages/docs/guide/backend.md
@@ -1,0 +1,3 @@
+# Backend Package
+
+<!-- @include: ../../backend/README.md -->

--- a/packages/docs/guide/daemon.md
+++ b/packages/docs/guide/daemon.md
@@ -1,0 +1,3 @@
+# Daemon Package
+
+<!-- @include: ../../daemon/README.md -->

--- a/packages/docs/guide/frontend.md
+++ b/packages/docs/guide/frontend.md
@@ -1,0 +1,3 @@
+# Frontend Package
+
+<!-- @include: ../../frontend/README.md -->

--- a/packages/docs/guide/shared.md
+++ b/packages/docs/guide/shared.md
@@ -1,0 +1,3 @@
+# Shared Package
+
+<!-- @include: ../../shared/README.md -->


### PR DESCRIPTION
## Summary
- Create guide pages for each package (backend, frontend, daemon, shared) using VitePress file includes
- Update sidebar navigation with new "Packages" section
- Package README changes now automatically reflected in the docs site

## Verification Performed
- [x] `npm run docs:build` completes without warnings
- [x] Manually verified docs render correctly at localhost
- [x] Links and navigation work
- [x] Package content displays properly with tables and code blocks

## Issue
Closes #43

---
*This PR targets `feature/docs-as-code`, not `main`.*