### PR TITLE
Closes #62: Deploy documentation to GitHub Pages on merge to master

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,57 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared package
+        run: npm run build -w @habit-tracker/shared
+
+      - name: Build documentation (generates TypeDoc + VitePress)
+        run: npm run docs:build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   title: 'Habit Tracker',
   description: 'A macOS app that blocks websites when daily habits are not completed',
 
+  // Base path for GitHub Pages deployment
+  base: '/habit-tracker/',
+
   // Map TypeDoc's README.md to index for VitePress
   rewrites: {
     'api/README.md': 'api/index.md',


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`deploy-docs.yml`) to deploy docs on push to master
- Configure VitePress base path (`/habit-tracker/`) for GitHub Pages compatibility
- Workflow builds shared package, generates TypeDoc API reference, and deploys VitePress site

## Manual Steps Required (after merge to master)
1. Go to repo Settings → Pages
2. Set Source to "GitHub Actions"
3. Docs will be available at https://paulbunker.github.io/habit-tracker/

## Verification Performed
- [x] `npm run docs:build` completes without warnings
- [x] Verified base path `/habit-tracker/` appears in built HTML assets
- [x] All navigation links include correct base path
- [ ] Code review requested

## Issue
Closes #62

---
*This PR targets `feature/docs-as-code`, not `master`.*